### PR TITLE
refactor(strum): refactor via strum_macros::Display

### DIFF
--- a/src/app/cargo.rs
+++ b/src/app/cargo.rs
@@ -15,13 +15,7 @@ use ratatui::{
     style::Color,
     widgets::{Block, BorderType, Borders, Paragraph},
 };
-use std::{
-    env,
-    fmt::{Debug, Display},
-    fs,
-    path::PathBuf,
-    process::Command,
-};
+use std::{env, fmt::Debug, fs, path::PathBuf, process::Command};
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter};
 #[derive(Clone, Copy, Display, EnumIter, FromPrimitive)]
@@ -67,24 +61,17 @@ impl RadioOptionValue for ProjectType {
         true
     }
 }
-#[derive(Clone, Copy, Debug, Default, EnumIter, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Display, EnumIter, PartialEq)]
 enum Edition {
+    #[strum(to_string = "2015")]
     Fifteen,
+    #[strum(to_string = "2018")]
     Eighteen,
+    #[strum(to_string = "2021")]
     TwentyOne,
     #[default]
+    #[strum(to_string = "2024")]
     TwentyFour,
-}
-impl Display for Edition {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct(match self {
-            Self::Fifteen => "2015",
-            Self::Eighteen => "2018",
-            Self::TwentyOne => "2021",
-            Self::TwentyFour => "2024",
-        })
-        .finish()
-    }
 }
 impl RadioOptionValue for Edition {
     fn selectable(&self) -> bool {

--- a/src/app/springboot.rs
+++ b/src/app/springboot.rs
@@ -20,13 +20,7 @@ use ratatui::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::{
-    env,
-    fmt::{Debug, Display},
-    fs,
-    path::PathBuf,
-    sync::OnceLock,
-};
+use std::{env, fmt::Debug, fs, path::PathBuf, sync::OnceLock};
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter};
 use tokio::sync::mpsc;
@@ -160,24 +154,17 @@ impl RadioOptionValue for Language {
         true
     }
 }
-#[derive(Clone, Copy, Default, Debug, EnumIter, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Display, EnumIter, PartialEq)]
 enum JavaVersion {
+    #[strum(to_string = "23")]
     TwentyThree,
+    #[strum(to_string = "21")]
     TwentyOne,
     #[default]
+    #[strum(to_string = "17")]
     Seventeen,
+    #[strum(to_string = "8")]
     Eight,
-}
-impl Display for JavaVersion {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct(match self {
-            Self::TwentyThree => "23",
-            Self::TwentyOne => "21",
-            Self::Seventeen => "17",
-            Self::Eight => "8",
-        })
-        .finish()
-    }
 }
 impl RadioOptionValue for JavaVersion {
     fn selectable(&self) -> bool {


### PR DESCRIPTION
use to_string property of strum attribute to declare how to format enum
items.
See https://docs.rs/strum_macros/latest/strum_macros/derive.Display.html
